### PR TITLE
fix #26

### DIFF
--- a/Trunk/PPC Manager/PPC Manager/Model/ZuXML.vb
+++ b/Trunk/PPC Manager/PPC Manager/Model/ZuXML.vb
@@ -44,8 +44,14 @@ Public Class ZuXML
 
         For Each i In Enumerable.Range(0, runden.Count)
             Dim runde = runden(i)
+            Dim rundenname = 0
+            If runde.Count > 0 Then
+                Dim match = runde(0)
+                rundenname = Integer.Parse(match.RundenName.Substring(match.RundenName.IndexOf(" ")))
+            End If
+
             For Each x In runde.AusgeschiedeneSpielerIDs
-                xSpielRunden.Add(<ppc:inactiveplayer player=<%= x %> group=<%= i %>/>)
+                xSpielRunden.Add(<ppc:inactiveplayer player=<%= x %> group=<%= rundenname %>/>)
             Next
         Next
 

--- a/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
@@ -80,7 +80,7 @@ Class MainWindow
     End Sub
 
     Public Function FilterSpieler(s As SpielerInfo) As Boolean
-        Return Not _Spielrunden.First.AusgeschiedeneSpielerIDs.Contains(s.Id)
+        Return Not _Spielrunden.Last.AusgeschiedeneSpielerIDs.Contains(s.Id)
     End Function
 
     Private Sub Ja(ByVal sender As Object, ByVal e As CanExecuteRoutedEventArgs)


### PR DESCRIPTION
Der Fix besteht aus einem Export Teil und einem Import Teil:

Export: Es wird nun für jeden Spieler die Runde (Group Attribut) in der
der Spieler ausgeschieden ist im XML gespeichert.

Import: Der Runden-Filter für die ausgeschiedenen Spieler beim Start hat
fälschlicherweise die neueste Runde anstatt Runde 0 verwendet, um nicht
erschienene Spieler auszusortieren.
(Runde 0 kommt im Stack zuletzt)