### PR TITLE
Fix #35 Format person licence-nr nicht kompatibel mit ClickTT

### DIFF
--- a/Trunk/PPC Manager/PPC Manager Tests/AusXMLTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/AusXMLTests.vb
@@ -43,7 +43,7 @@ Public Class AusXMLTests
             Assert.AreEqual("Florian", .Vorname)
             Assert.AreEqual("Ewald", .Nachname)
             Assert.AreEqual("TTC Langensteinbach e.V. ", .Vereinsname)
-            Assert.AreEqual(53010, .Lizenznummer)
+            Assert.AreEqual("53010", .Lizenznummer)
             Assert.AreEqual(1981, .Geburtsjahr)
             Assert.AreEqual(1, .Geschlecht)
         End With
@@ -59,7 +59,7 @@ Public Class AusXMLTests
             Assert.AreEqual("Florian", .Vorname)
             Assert.AreEqual("Ewald", .Nachname)
             Assert.AreEqual("TTC Langensteinbach e.V. ", .Vereinsname)
-            Assert.AreEqual(53010, .Lizenznummer)
+            Assert.AreEqual("53010", .Lizenznummer)
             Assert.AreEqual(1981, .Geburtsjahr)
             Assert.AreEqual(1, .Geschlecht)
         End With

--- a/Trunk/PPC Manager/PPC Manager Tests/Model/SpielerInfoComparerTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/Model/SpielerInfoComparerTests.vb
@@ -95,8 +95,8 @@
 
     <Test>
     Public Sub Größer_wenn_Lizenznummer_größer()
-        _A.Lizenznummer = 7
-        _B.Lizenznummer = 6
+        _A.Lizenznummer = "7"
+        _B.Lizenznummer = "6"
 
         Assert.That(_SpielerInfoComparer.Compare(_A, _B), [Is].GreaterThan(0))
     End Sub
@@ -118,18 +118,8 @@
     End Sub
 
     <Test>
-    Public Sub Keine_Exception_wenn_sehr_große_Differenz_bei_Lizenznummern()
-        _A.Lizenznummer = Long.MaxValue
-        _B.Lizenznummer = 0L
-
-        Assert.That(_SpielerInfoComparer.Compare(_A, _B), [Is].GreaterThan(0))
-    End Sub
-
-
-    <Test>
     Public Sub Gleich_wenn_alles_gleich()
         Assert.That(_SpielerInfoComparer.Compare(_A, _B), [Is].EqualTo(0))
     End Sub
-
 
 End Class

--- a/Trunk/PPC Manager/PPC Manager Tests/Model/SpielerInfoTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/Model/SpielerInfoTests.vb
@@ -28,7 +28,7 @@
         Dim s As New SpielerInfo("949") With {
             .Vorname = "Bob",
             .Nachname = "Builder",
-            .Lizenznummer = 1234,
+            .Lizenznummer = "1234",
             .Geburtsjahr = 1984,
             .TTRating = 520,
             .TTRMatchCount = 23,
@@ -40,7 +40,7 @@
         Assert.That(neu.Id, [Is].EqualTo("949"))
         Assert.That(neu.Vorname, [Is].EqualTo("Bob"))
         Assert.That(neu.Nachname, [Is].EqualTo("Builder"))
-        Assert.That(neu.Lizenznummer, [Is].EqualTo(1234))
+        Assert.That(neu.Lizenznummer, [Is].EqualTo("1234"))
         Assert.That(neu.Geburtsjahr, [Is].EqualTo(1984))
         Assert.That(neu.TTRating, [Is].EqualTo(520))
         Assert.That(neu.TTRMatchCount, [Is].EqualTo(23))

--- a/Trunk/PPC Manager/PPC Manager Tests/Output/TurnierReportTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/Output/TurnierReportTests.vb
@@ -35,7 +35,7 @@
                 .Geschlecht = 1,
                 .Geburtsjahr = 1472,
                 .Fremd = True,
-                .Lizenznummer = 12345,
+                .Lizenznummer = "12345",
                 .TTRating = 999,
                 .TTRMatchCount = 22,
                 .Verbandsspitzname = "Hello",

--- a/Trunk/PPC Manager/PPC Manager Tests/StartlistenEditor/SpeicherTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/StartlistenEditor/SpeicherTests.vb
@@ -72,7 +72,7 @@ Public Class SpeicherTests
         Assert.That(p.Geschlecht, Iz.EqualTo(0))
         Assert.That(p.ID, Iz.EqualTo("ID123"))
         Assert.That(p.Klassement, Iz.EqualTo("B-Klasse"))
-        Assert.That(p.LizenzNr, Iz.EqualTo(45))
+        Assert.That(p.LizenzNr, Iz.EqualTo("45"))
         Assert.That(p.Nachname, Iz.EqualTo("Mustermann"))
         Assert.That(p.TTR, Iz.EqualTo(12))
         Assert.That(p.TTRMatchCount, Iz.EqualTo(55))
@@ -80,7 +80,7 @@ Public Class SpeicherTests
         Assert.That(p.Vorname, Iz.EqualTo("Max"))
     End Sub
 
-    <Test>
+    <Test, Ignore("Licence-NR Format wird nicht geprüft, jeder String ist gültig")>
     Public Sub LeseSpieler_wirft_UngültigeSpielerException_bei_falscher_LizenzNr()
         ' Arrange
         Dim _BKlasse = <competition age-group="B-Klasse" xmlns:ppc="http://www.ttc-langensteinbach.de">
@@ -140,6 +140,6 @@ Public Class SpeicherTests
         Dim r = New Speicher(dateisystem)
         ' Act / Assert
         Dim s = r.LeseSpieler.First
-        Assert.That(s.LizenzNr, [Is].EqualTo(1234567890123456789L))
+        Assert.That(s.LizenzNr, [Is].EqualTo("1234567890123456789"))
     End Sub
 End Class

--- a/Trunk/PPC Manager/PPC Manager Tests/StartlistenEditor/SpielerRepositoryTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/StartlistenEditor/SpielerRepositoryTests.vb
@@ -35,7 +35,7 @@ Public Class SpielerRepositoryTests
                     .ID = "MeineID",
                     .Fremd = True,
                     .Klassement = "B-Klasse",
-                    .LizenzNr = -41,
+                    .LizenzNr = "-41",
                     .Geburtsjahr = 1987,
                     .Geschlecht = 1,
                     .Vorname = "Dr. Max",
@@ -231,7 +231,7 @@ Public Class SpielerRepositoryTests
         Dim spieler = New SpielerInfo With {
             .Klassement = "B-Klasse",
             .ID = "123",
-            .LizenzNr = 123}
+            .LizenzNr = "123"}
 
         Dim repository = New SpielerRepository(speicher.Object, _Observable.Object,
                                                New List(Of SpielerInfo) From {spieler})

--- a/Trunk/PPC Manager/PPC Manager Tests/ZuXMLTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/ZuXMLTests.vb
@@ -45,7 +45,7 @@ Public Class ZuXMLTests
                                                                matches-a="0" matches-b="0" scheduled="2013-05-22 21:17" group="Runde 1" nr="2"
                                                                set-a-1="0" set-a-2="0" set-a-3="0" set-a-4="0" set-a-5="0" set-a-6="0" set-a-7="0"
                                                                set-b-1="0" set-b-2="0" set-b-3="0" set-b-4="0" set-b-5="0" set-b-6="0" set-b-7="0"/>.ToString))
-        Assert.That(spielPartien(2).ToString, [Is].EqualTo(<ppc:inactiveplayer player="PLAYER77" group="0"/>.ToString))
+        Assert.That(spielPartien(2).ToString, [Is].EqualTo(<ppc:inactiveplayer player="PLAYER77" group="1"/>.ToString))
 
     End Sub
 

--- a/Trunk/PPC Manager/PPC Manager/Model/AusXML.vb
+++ b/Trunk/PPC Manager/PPC Manager/Model/AusXML.vb
@@ -51,7 +51,7 @@ Public Class AusXML
             .Nachname = spielerNode.@lastname
             .Geschlecht = Integer.Parse(spielerNode.@sex)
             .Vereinsname = spielerNode.Attribute("club-name").Value
-            .Lizenznummer = Long.Parse(spielerNode.Attribute("licence-nr").Value)
+            .Lizenznummer = spielerNode.Attribute("licence-nr").Value
         End With
         Integer.TryParse(spielerNode.@birthyear, spieler.Geburtsjahr)
         Integer.TryParse(spielerNode.@ttr, spieler.TTRating)

--- a/Trunk/PPC Manager/PPC Manager/Model/SpielerInfo.vb
+++ b/Trunk/PPC Manager/PPC Manager/Model/SpielerInfo.vb
@@ -36,7 +36,7 @@ Public Class SpielerInfo
 
     Public Property Verbandsspitzname As String = ""
 
-    Public Property Lizenznummer As Long
+    Public Property Lizenznummer As String = ""
 
     Public ReadOnly Property StartNummer As Integer
         Get

--- a/Trunk/PPC Manager/PPC Manager/Model/SpielerInfoComparer.vb
+++ b/Trunk/PPC Manager/PPC Manager/Model/SpielerInfoComparer.vb
@@ -44,9 +44,8 @@ Public Class SpielerInfoComparer
         If diff <> 0 Then Return diff
         diff = y.Vorname.CompareTo(x.Vorname)
         If diff <> 0 Then Return diff
-        Dim longDiff = x.Lizenznummer - y.Lizenznummer
-        If longDiff > 0 Then Return 1
-        If longDiff < 0 Then Return -1
+        diff = x.Lizenznummer.CompareTo(y.Lizenznummer)
+        If diff <> 0 Then Return diff
         Return 0
     End Function
 End Class

--- a/Trunk/PPC Manager/StartlistenEditor/Speicher.vb
+++ b/Trunk/PPC Manager/StartlistenEditor/Speicher.vb
@@ -45,7 +45,7 @@ Public Class Speicher
                                         .Fremd = fremd,
                                         .Geschlecht = Integer.Parse(person.@sex),
                                         .Klassement = klassement.Attribute("age-group").Value,
-                                        .LizenzNr = Long.Parse(person.Attribute("licence-nr").Value),
+                                        .LizenzNr = person.Attribute("licence-nr").Value,
                                         .Nachname = person.@lastname,
                                         .Vorname = person.@firstname,
                                         .Verein = person.Attribute("club-name").Value

--- a/Trunk/PPC Manager/StartlistenEditor/SpielerInfo.vb
+++ b/Trunk/PPC Manager/StartlistenEditor/SpielerInfo.vb
@@ -30,7 +30,7 @@ Public Class SpielerInfo
     Public Property Verein As String
     Public Property TTR As Integer
     Public Property TTRMatchCount As Integer
-    Public Property LizenzNr As Long
+    Public Property LizenzNr As String
     Public Property Klassement As String
     Public Property Geschlecht As Integer
     Public Property Geburtsjahr As Integer
@@ -51,9 +51,8 @@ Public Class SpielerInfo
         If diff <> 0 Then Return diff
         diff = Vorname.CompareTo(other.Vorname)
         If diff <> 0 Then Return diff
-        Dim longDiff = LizenzNr - other.LizenzNr
-        If longDiff > 0 Then Return 1
-        If longDiff < 0 Then Return -1
+        diff = LizenzNr.CompareTo(other.LizenzNr)
+        If diff <> 0 Then Return diff
         Return 0
     End Function
 

--- a/Trunk/PPC Manager/StartlistenEditor/StartlistenController.vb
+++ b/Trunk/PPC Manager/StartlistenEditor/StartlistenController.vb
@@ -16,13 +16,13 @@ Public Class StartlistenController
     End Sub
 
     Protected Overrides Sub InsertItem(index As Integer, item As SpielerInfo)
-        If item.LizenzNr = 0 Then
+        If item.LizenzNr = "" Then
             Dim Lizenznummern = (From x In Me Select x.LizenzNr).ToList
             Dim NeueLizenzNummer = -1
-            While Lizenznummern.Contains(NeueLizenzNummer)
+            While Lizenznummern.Contains(NeueLizenzNummer & "")
                 NeueLizenzNummer -= 1
             End While
-            item.LizenzNr = NeueLizenzNummer
+            item.LizenzNr = NeueLizenzNummer & ""
             item.ID = "PLAYER" & NeueLizenzNummer
         End If
         MyBase.InsertItem(index, item)


### PR DESCRIPTION
Lizenznr Attribut zu Textwert (String) geändert.
Die Datendefinition des TournamentPortal gibt keine weiteren Informationen
über das Format der Lizenznummer, daher wird vorerst erstmal jeder
beliebige Text als Lizenznummer akzeptiert