### PR TITLE
Druckfunktion überarbeitet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /Trunk/PPC Manager/PPC Manager Tests/Resources/Protokolle
 /Trunk/PPC Manager/packages/**
 !/Trunk/PPC Manager/packages/repositories.config
-/Trunk/PPC Manager/UpgradeLog.htm
+/Trunk/PPC Manager/UpgradeLog*.htm
 /Trunk/PPC Manager/.vs/**
 /.vs/**
 bin

--- a/Trunk/PPC Manager/PPC Manager Tests/AusXMLTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/AusXMLTests.vb
@@ -81,8 +81,8 @@ Public Class AusXMLTests
         With Partie
             CollectionAssert.AreEqual({5, 9, 9}, .Select(Function(x) x.PunkteRechts).ToList)
             CollectionAssert.AreEqual({11, 11, 11}, .Select(Function(x) x.PunkteLinks).ToList)
-            Assert.AreEqual(SpielerB, .MeinGegner(SpielerA))
-            Assert.AreEqual(SpielerA, .MeinGegner(SpielerB))
+            Assert.AreEqual(SpielerB, .GegnerVon(SpielerA))
+            Assert.AreEqual(SpielerA, .GegnerVon(SpielerB))
         End With
     End Sub
 
@@ -100,8 +100,8 @@ Public Class AusXMLTests
         With Partie
             CollectionAssert.AreEqual({5, 0, 9}, .Select(Function(x) x.PunkteRechts).ToList)
             CollectionAssert.AreEqual({11, 11, 11}, .Select(Function(x) x.PunkteLinks).ToList)
-            Assert.AreEqual(SpielerB, .MeinGegner(SpielerA))
-            Assert.AreEqual(SpielerA, .MeinGegner(SpielerB))
+            Assert.AreEqual(SpielerB, .GegnerVon(SpielerA))
+            Assert.AreEqual(SpielerA, .GegnerVon(SpielerB))
         End With
     End Sub
 End Class

--- a/Trunk/PPC Manager/PPC Manager Tests/FixedPageFabrikTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/FixedPageFabrikTests.vb
@@ -34,12 +34,7 @@ Public Class FixedPageFabrikTests
     Private f As FixedPageFabrik
     Private _SpielerListe As IList(Of SpielerInfo)
     Private _Runden As SpielRunden
-
-    <Test>
-    Public Sub ErzeugeRanglisteSeiten_leer_enthält_eine_Seite()
-        Dim seiten = f.ErzeugeRanglisteSeiten(_SeitenEinstellungen)
-        Assert.That(seiten.Count, [Is].EqualTo(1))
-    End Sub
+  
 
     <Test>
     Public Sub ErzeugeRanglisteSeiten_mit_200_spielern_ergibt_mehrere_Seiten()

--- a/Trunk/PPC Manager/PPC Manager Tests/KonverterTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/KonverterTests.vb
@@ -10,14 +10,14 @@ Imports Moq
     Public Sub GeschlechtKonverter_0_w()
         Dim converter As New GeschlechtKonverter
         Dim result = converter.Convert(0, Nothing, Nothing, Nothing)
-        Assert.AreEqual("w", result)
+        Assert.AreEqual("W", result)
     End Sub
 
     <Test>
     Public Sub GeschlechtKonverter_1_m()
         Dim converter As New GeschlechtKonverter
         Dim result = converter.Convert(1, Nothing, Nothing, Nothing)
-        Assert.AreEqual("m", result)
+        Assert.AreEqual("M", result)
     End Sub
 
     <Test>

--- a/Trunk/PPC Manager/PPC Manager Tests/RanglisteSeiteTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/RanglisteSeiteTests.vb
@@ -8,7 +8,8 @@ Public Class RanglisteSeiteTests
         _RangListe = New RanglisteSeite("Altersgruppe",
                                         {s},
                                         New List(Of SpielRunde)({Mock.Of(Of SpielRunde), Mock.Of(Of SpielRunde)}),
-                                        Mock.Of(Of ISpielstand))
+                                        Mock.Of(Of ISpielstand),
+                                        Mock.Of(Of SeitenEinstellung))
     End Sub
 
     Dim _RangListe As RanglisteSeite

--- a/Trunk/PPC Manager/PPC Manager Tests/RanglisteSeiteTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/RanglisteSeiteTests.vb
@@ -5,9 +5,10 @@ Public Class RanglisteSeiteTests
     Public Sub Init()
         Dim spielverlauf = Mock.Of(Of ISpielverlauf(Of SpielerInfo))
         Dim s As New Spieler(New SpielerInfo("A"), spielverlauf, Mock.Of(Of IComparer(Of SpielerInfo)))
-        _RangListe = New RanglisteSeite("Altersgruppe", 2,
+        _RangListe = New RanglisteSeite("Altersgruppe",
                                         {s},
-                                        New List(Of SpielPartie), Mock.Of(Of ISpielstand))
+                                        New List(Of SpielRunde)({Mock.Of(Of SpielRunde), Mock.Of(Of SpielRunde)}),
+                                        Mock.Of(Of ISpielstand))
     End Sub
 
     Dim _RangListe As RanglisteSeite
@@ -19,7 +20,7 @@ Public Class RanglisteSeiteTests
 
     <Test>
     Public Sub Rundennummer_steht_im_Textfeld()
-        Assert.That(_RangListe.RundenNummer.Text, [Is].EqualTo("Runde Nr. 2"))
+        Assert.That(_RangListe.RundenNummer.Text, [Is].EqualTo("Runde Nr. 1"))
     End Sub
 
     <Test>

--- a/Trunk/PPC Manager/PPC Manager Tests/RanglisteSeiteTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/RanglisteSeiteTests.vb
@@ -9,7 +9,8 @@ Public Class RanglisteSeiteTests
                                         {s},
                                         New List(Of SpielRunde)({Mock.Of(Of SpielRunde), Mock.Of(Of SpielRunde)}),
                                         Mock.Of(Of ISpielstand),
-                                        Mock.Of(Of SeitenEinstellung))
+                                        Mock.Of(Of SeitenEinstellung),
+                                        0)
     End Sub
 
     Dim _RangListe As RanglisteSeite

--- a/Trunk/PPC Manager/PPC Manager Tests/View/DruckEinstellungenDialogTests.vb
+++ b/Trunk/PPC Manager/PPC Manager Tests/View/DruckEinstellungenDialogTests.vb
@@ -6,7 +6,15 @@ Public Class DruckEinstellungenDialogTests
         Dim einstellungen As New DruckEinstellungen
         einstellungen.DruckeNeuePaarungen = True
         einstellungen.DruckeSpielergebnisse = True
-        Dim d = New DruckEinstellungenDialog()
+        Dim druckFabrik = New DruckerFabrik()
+        Dim pageFabrik = Mock.Of(Of IFixedPageFabrik)
+        Dim Controller = New MainWindowController(Sub()
+
+                                                  End Sub,
+                                                  Mock.Of(Of IReportFactory),
+                                                  Function() New PaarungsContainer(Of SpielerInfo),
+                                                  pageFabrik)
+        Dim d = New DruckEinstellungenDialog(Controller, druckFabrik)
         d.DataContext = einstellungen
         Dim result = d.ShowDialog()
     End Sub

--- a/Trunk/PPC Manager/PPC Manager/IPrinter.vb
+++ b/Trunk/PPC Manager/PPC Manager/IPrinter.vb
@@ -32,7 +32,8 @@ Public Class Printer
             .AbstandX = area.OriginWidth,
             .AbstandY = area.OriginHeight,
             .Breite = area.ExtentWidth,
-            .Höhe = area.ExtentHeight}
+            .Höhe = area.ExtentHeight
+        }
 
         Return einstellung
     End Function

--- a/Trunk/PPC Manager/PPC Manager/IPrinter.vb
+++ b/Trunk/PPC Manager/PPC Manager/IPrinter.vb
@@ -8,7 +8,6 @@ Public Interface IPrinter
 
 End Interface
 
-
 Public Class SeitenEinstellung
 
     Public Property AbstandX As Double
@@ -28,14 +27,12 @@ Public Class Printer
 
     Public Function LeseKonfiguration() As SeitenEinstellung Implements IPrinter.LeseKonfiguration
         Dim area = _PrintDialog.PrintQueue.GetPrintCapabilities.PageImageableArea
-        Dim einstellung = New SeitenEinstellung() With {
+        Return New SeitenEinstellung() With {
             .AbstandX = area.OriginWidth,
             .AbstandY = area.OriginHeight,
             .Breite = area.ExtentWidth,
             .Höhe = area.ExtentHeight
         }
-
-        Return einstellung
     End Function
 
     Public Sub Drucken(doc As FixedDocument, titel As String) Implements IPrinter.Drucken
@@ -43,6 +40,5 @@ Public Class Printer
         If doc.Pages.Any Then
             _PrintDialog.PrintDocument(doc.DocumentPaginator, titel)
         End If
-
     End Sub
 End Class

--- a/Trunk/PPC Manager/PPC Manager/IPrinter.vb
+++ b/Trunk/PPC Manager/PPC Manager/IPrinter.vb
@@ -38,7 +38,13 @@ Public Class Printer
     Public Sub Drucken(doc As FixedDocument, titel As String) Implements IPrinter.Drucken
         doc.PrintTicket = _PrintDialog.PrintTicket
         If doc.Pages.Any Then
-            _PrintDialog.PrintDocument(doc.DocumentPaginator, titel)
+            Try
+                _PrintDialog.PrintDocument(doc.DocumentPaginator, titel)
+            Catch ex As Exception
+                Dim Message = String.Format("Dokument '{0}' konnte nicht gedruckt oder gespeichert werden. Ist die Datei in einer anderen Anwendung geöffnet?", titel)
+                Dim Caption = "Fehler"
+                MessageBox.Show(Message, Caption, MessageBoxButton.OK, MessageBoxImage.Error)
+            End Try
         End If
     End Sub
 End Class

--- a/Trunk/PPC Manager/PPC Manager/Konverter.vb
+++ b/Trunk/PPC Manager/PPC Manager/Konverter.vb
@@ -134,7 +134,7 @@ Public Class OpacityConverter
 
     Public Function Convert(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.Convert
         Dim partie = CType(value, SpielPartie)
-        If IstAbgeschlossen(partie) Then
+        If IstAbgeschlossen(partie) Or TypeOf partie Is FreiLosSpiel Then
             Return 0.4
         Else
             Return 1.0

--- a/Trunk/PPC Manager/PPC Manager/Konverter.vb
+++ b/Trunk/PPC Manager/PPC Manager/Konverter.vb
@@ -155,10 +155,16 @@ Public Class GewonneneSätzeConverter
         Dim partie = TryCast(value, SpielPartie)
         If partie Is Nothing Then Return Nothing
 
-        Dim gewonnenLinks = MeineGewonnenenSätze(partie, partie.SpielerLinks)
-        Dim gewonnenRechts = MeineGewonnenenSätze(partie, partie.SpielerRechts)
+        With partie
+            If .SpielerLinks Is .SpielerRechts Then
+                Return "Freilos"
+            End If
 
-        Return String.Format("{0}:{1}", gewonnenLinks, gewonnenRechts)
+            Dim gewonnenLinks = MeineGewonnenenSätze(partie, .SpielerLinks)
+            Dim gewonnenRechts = MeineGewonnenenSätze(partie, .SpielerRechts)
+
+            Return String.Format("{0}:{1}", gewonnenLinks, gewonnenRechts)
+        End With
     End Function
 
     Public Function ConvertBack(value As Object, targetType As Type, parameter As Object, culture As Globalization.CultureInfo) As Object Implements IValueConverter.ConvertBack

--- a/Trunk/PPC Manager/PPC Manager/Konverter.vb
+++ b/Trunk/PPC Manager/PPC Manager/Konverter.vb
@@ -6,8 +6,8 @@ Public Class GeschlechtKonverter
     Public Function Convert(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.Convert
         Dim geschlecht = DirectCast(value, Integer)
         Select Case geschlecht
-            Case 0 : Return "w"
-            Case 1 : Return "m"
+            Case 0 : Return "W"
+            Case 1 : Return "M"
         End Select
         Throw New ArgumentException("Unbekanntes geschlecht: " & geschlecht)
     End Function

--- a/Trunk/PPC Manager/PPC Manager/MainWindowController.vb
+++ b/Trunk/PPC Manager/PPC Manager/MainWindowController.vb
@@ -8,18 +8,18 @@ Public Class MainWindowController
     Public Sub New(speichern As Action,
                    reportFactory As IReportFactory,
                    organisierePakete As OrganisierePakete,
-                   druckFabrik As IFixedPageFabrik
+                   pageFabrik As IFixedPageFabrik
                    )
         _Speichern = speichern
         _ReportFactory = reportFactory
         _OrganisierePakete = organisierePakete
-        _DruckFabrik = druckFabrik
+        _PageFabrik = pageFabrik
     End Sub
 
     Private ReadOnly _Speichern As Action
     Private ReadOnly _ReportFactory As IReportFactory
     Private ReadOnly _OrganisierePakete As OrganisierePakete
-    Private ReadOnly _DruckFabrik As IFixedPageFabrik
+    Private ReadOnly _PageFabrik As IFixedPageFabrik
     Private ReadOnly _GewinnSätze As Integer
 
     Public ReadOnly Property ExcelPfad As String Implements IController.ExcelPfad
@@ -62,7 +62,7 @@ Public Class MainWindowController
 
     Public Function DruckeSchiedsrichterzettel(seiteneinstellung As SeitenEinstellung) As FixedDocument Implements IController.DruckeSchiedsrichterzettel
         Dim doc = New FixedDocument
-        Dim schiriSeiten = From x In _DruckFabrik.ErzeugeSchiedsrichterZettelSeiten(seiteneinstellung)
+        Dim schiriSeiten = From x In _PageFabrik.ErzeugeSchiedsrichterZettelSeiten(seiteneinstellung)
                            Select New PageContent() With {.Child = x}
 
         For Each page In schiriSeiten
@@ -72,7 +72,7 @@ Public Class MainWindowController
     End Function
 
     Public Function DruckeNeuePaarungen(seiteneinstellung As SeitenEinstellung) As FixedDocument Implements IController.DruckeNeuePaarungen
-        Dim neuePaarungenSeiten = From x In _DruckFabrik.ErzeugePaarungen(seiteneinstellung)
+        Dim neuePaarungenSeiten = From x In _PageFabrik.ErzeugePaarungen(seiteneinstellung)
                                   Select New PageContent() With {.Child = x}
 
         Dim doc = New FixedDocument
@@ -85,7 +85,7 @@ Public Class MainWindowController
 
     Public Function DruckeRangliste(seiteneinstellung As SeitenEinstellung) As FixedDocument Implements IController.DruckeRangliste
         Dim doc = New FixedDocument
-        Dim ranglistenSeiten = From x In _DruckFabrik.ErzeugeRanglisteSeiten(
+        Dim ranglistenSeiten = From x In _PageFabrik.ErzeugeRanglisteSeiten(
                                    seiteneinstellung)
                                Select New PageContent() With {.Child = x}
 
@@ -96,7 +96,7 @@ Public Class MainWindowController
     End Function
 
     Public Function DruckeSpielergebnisse(seiteneinstellung As SeitenEinstellung) As FixedDocument Implements IController.DruckeSpielergebnisse
-        Dim spielErgebnisSeiten = From x In _DruckFabrik.ErzeugeSpielErgebnisse(
+        Dim spielErgebnisSeiten = From x In _PageFabrik.ErzeugeSpielErgebnisse(
                                       seiteneinstellung)
                                   Select New PageContent() With {.Child = x}
 

--- a/Trunk/PPC Manager/PPC Manager/Model/SpielPartie.vb
+++ b/Trunk/PPC Manager/PPC Manager/Model/SpielPartie.vb
@@ -13,7 +13,7 @@ Imports System.Collections.ObjectModel
 Public Class SpielPartie
     Inherits ObservableCollection(Of Satz)
 
-    Private ReadOnly Spieler As KeyValuePair(Of SpielerInfo, SpielerInfo)
+    Private ReadOnly Kontrahenten As Tuple(Of SpielerInfo, SpielerInfo)
     Private ReadOnly _RundenName As String
     Public ReadOnly Property RundenName As String
         Get
@@ -25,34 +25,33 @@ Public Class SpielPartie
     Public Sub New(rundenName As String, ByVal spielerLinks As SpielerInfo, ByVal spielerRechts As SpielerInfo)
         If spielerLinks Is Nothing Then Throw New ArgumentNullException
         If spielerRechts Is Nothing Then Throw New ArgumentNullException
-
-        Spieler = New KeyValuePair(Of SpielerInfo, SpielerInfo)(spielerLinks, spielerRechts)
+        Kontrahenten = Tuple.Create(spielerLinks, spielerRechts)
         _RundenName = rundenName
-        AddHandler Me.CollectionChanged, Sub()
-                                             Me.OnPropertyChanged(New PropertyChangedEventArgs("MySelf"))
-                                         End Sub
+        AddHandler CollectionChanged, Sub()
+                                          OnPropertyChanged(New PropertyChangedEventArgs("MySelf"))
+                                      End Sub
     End Sub
 
     Public ReadOnly Property SpielerLinks As SpielerInfo
         Get
-            Return Spieler.Key
+            Return Kontrahenten.Item1
         End Get
     End Property
 
     Public ReadOnly Property SpielerRechts As SpielerInfo
         Get
-            Return Spieler.Value
+            Return Kontrahenten.Item2
         End Get
     End Property
 
     Public Property ZeitStempel As Date
 
-    Public ReadOnly Property MeinGegner(ByVal ich As SpielerInfo) As SpielerInfo
+    Public ReadOnly Property GegnerVon(ByVal Spieler As SpielerInfo) As SpielerInfo
         Get
-            If Spieler.Key = ich Then
-                Return Spieler.Value
+            If SpielerLinks = Spieler Then
+                Return SpielerRechts
             Else
-                Return Spieler.Key
+                Return SpielerLinks
             End If
         End Get
     End Property
@@ -60,9 +59,9 @@ Public Class SpielPartie
     Public Overrides Function Equals(obj As Object) As Boolean
         Dim other = TryCast(obj, SpielPartie)
         If other Is Nothing Then Return False
-        If Me.SpielerLinks <> other.SpielerLinks Then Return False
-        If Me.SpielerRechts <> other.SpielerRechts Then Return False
-        If Me.RundenName <> other.RundenName Then Return False
+        If SpielerLinks <> other.SpielerLinks Then Return False
+        If SpielerRechts <> other.SpielerRechts Then Return False
+        If RundenName <> other.RundenName Then Return False
         Return True
     End Function
 
@@ -79,7 +78,6 @@ Public Class SpielPartie
             Return Me
         End Get
     End Property
-
 
     Public Overrides Function GetHashCode() As Integer
         Return SpielerLinks.GetHashCode Xor SpielerRechts.GetHashCode Xor RundenName.GetHashCode

--- a/Trunk/PPC Manager/PPC Manager/Model/Spielverlauf.vb
+++ b/Trunk/PPC Manager/PPC Manager/Model/Spielverlauf.vb
@@ -107,6 +107,6 @@ Public Class Spielverlauf
     Public Function BerechneGegnerProfil(s As SpielerInfo) As IEnumerable(Of String) Implements ISpielverlauf(Of SpielerInfo).BerechneGegnerProfil
         Dim gespieltePartien = From x In _Spielpartien
                                Where x.SpielerLinks = s Or x.SpielerRechts = s
-        Return From x In gespieltePartien Select x.MeinGegner(s).Id
+        Return From x In gespieltePartien Select x.GegnerVon(s).Id
     End Function
 End Class

--- a/Trunk/PPC Manager/PPC Manager/My Project/AssemblyInfo.vb
+++ b/Trunk/PPC Manager/PPC Manager/My Project/AssemblyInfo.vb
@@ -56,6 +56,6 @@ Imports System.Runtime.CompilerServices
 ' übernehmen, indem Sie "*" eingeben:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.2.*")>
-<Assembly: AssemblyFileVersion("1.0.0.0")> 
+<Assembly: AssemblyVersion("1.3.*")>
+<Assembly: AssemblyFileVersion("1.3")>
 <Assembly: InternalsVisibleTo("PPC Manager Tests")> 

--- a/Trunk/PPC Manager/PPC Manager/My Project/AssemblyInfo.vb
+++ b/Trunk/PPC Manager/PPC Manager/My Project/AssemblyInfo.vb
@@ -13,12 +13,12 @@ Imports System.Runtime.CompilerServices
 ' Die Werte der Assemblyattribute überprüfen
 
 <Assembly: AssemblyTitle("PPC Manager")> 
-<Assembly: AssemblyDescription("Zum Verwalten und Durchführen des Ping Pong Café")> 
-<Assembly: AssemblyCompany("Marius Goppelt")> 
-<Assembly: AssemblyProduct("PPC Manager")> 
-<Assembly: AssemblyCopyright("Marius Goppelt 2010")> 
-<Assembly: AssemblyTrademark("")> 
-<Assembly: ComVisible(False)> 
+<Assembly: AssemblyDescription("Zum Verwalten und Durchführen des Ping Pong Café")>
+<Assembly: AssemblyCompany("Marius Goppelt, Nikolaj Kappler")>
+<Assembly: AssemblyProduct("PPC Manager")>
+<Assembly: AssemblyCopyright("Marius Goppelt, Nikolaj Kappler 2010 - 2022")>
+<Assembly: AssemblyTrademark("")>
+<Assembly: ComVisible(False)>
 
 'Um mit dem Erstellen lokalisierbarer Anwendungen zu beginnen, legen Sie 
 '<UICulture>ImCodeVerwendeteKultur</UICulture> in der VBPROJ-Datei
@@ -43,7 +43,7 @@ Imports System.Runtime.CompilerServices
 
 
 'Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
-<Assembly: Guid("ab0ec590-3387-4cbe-8542-d63fedc5e375")> 
+<Assembly: Guid("ab0ec590-3387-4cbe-8542-d63fedc5e375")>
 
 ' Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
 '
@@ -56,6 +56,6 @@ Imports System.Runtime.CompilerServices
 ' übernehmen, indem Sie "*" eingeben:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.0.0.0")> 
+<Assembly: AssemblyVersion("1.2.*")>
 <Assembly: AssemblyFileVersion("1.0.0.0")> 
 <Assembly: InternalsVisibleTo("PPC Manager Tests")> 

--- a/Trunk/PPC Manager/PPC Manager/Output/FixedPageFabrik.vb
+++ b/Trunk/PPC Manager/PPC Manager/Output/FixedPageFabrik.vb
@@ -31,7 +31,7 @@ Public Class FixedPageFabrik
         If _SpielRunden.Any Then
             spielPartien = _SpielRunden.Peek.Where(Function(m) Not TypeOf m Is FreiLosSpiel).ToList
         End If
-        Dim seite = New RanglisteSeite(_KlassementName, _SpielRunden.Count - 1, l, spielPartien, _Spielstand)
+        Dim seite = New RanglisteSeite(_KlassementName, l, _SpielRunden, _Spielstand)
         With seite
             Dim canvas = New Canvas
             canvas.Children.Add(seite)

--- a/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml
+++ b/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml
@@ -41,7 +41,7 @@
                 </Style>
             </DataGrid.Resources>
             <DataGrid.Columns>
-                <DataGridTextColumn x:Name="NummerColumn" Header="Rang">
+                <DataGridTextColumn x:Name="NummerColumn" Header="Rang" HeaderStyle="{StaticResource Rotate270}">
                     <DataGridTextColumn.Binding>
                         <MultiBinding Converter="{StaticResource GridIndexConverter}">
                             <Binding />
@@ -68,7 +68,7 @@
                 <DataGridTemplateColumn Header="Gegnerprofil">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ItemsControl  ItemsSource="{Binding Path=MeineSpieleDruck}">
+                            <ItemsControl ItemsSource="{Binding Path=GegnerProfil}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <VirtualizingStackPanel Orientation="Horizontal"/>

--- a/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml
+++ b/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml
@@ -12,7 +12,10 @@
         <local:RangListeSpielerListe x:Key="Spieler"/>
         <local:GridIndexConverter x:Key="GridIndexConverter"/>
     </UserControl.Resources>
-    <Grid Margin="20">
+    <Grid Margin="20" x:Name="Container">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="20"/>
             <RowDefinition Height="*"/>
@@ -24,7 +27,7 @@
             <TextBlock x:Name="RundenNummer" Grid.Row="0" Text="Runde Nr. 4" Margin="20,0,0,0"/>
         </StackPanel>
 
-        <DataGrid Grid.Row="1" x:Name="SpielerRangListe" DataContext="{StaticResource Spieler}" d:DataContext="{d:DesignInstance Type=local:DesignSpielerListe, IsDesignTimeCreatable=True}" ItemsSource="{Binding}" RowHeight="20" HeadersVisibility="Column" GridLinesVisibility="Horizontal" CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled" AutoGenerateColumns="False" IsSynchronizedWithCurrentItem="False" Grid.RowSpan="2">
+        <DataGrid Grid.Row="1" MinRowHeight="20" x:Name="SpielerRangListe" DataContext="{StaticResource Spieler}" d:DataContext="{d:DesignInstance Type=local:DesignSpielerListe, IsDesignTimeCreatable=True}" ItemsSource="{Binding}" HeadersVisibility="Column" GridLinesVisibility="Horizontal" CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled" AutoGenerateColumns="False" IsSynchronizedWithCurrentItem="False" Grid.RowSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top">
             <DataGrid.Resources>
                 <Style x:Name="Rotate270" x:Key="Rotate270" 
                TargetType="{x:Type DataGridColumnHeader}" >
@@ -65,13 +68,13 @@
                 <DataGridTextColumn Header="BHP" Binding="{Binding BuchholzPunkte}" HeaderStyle="{StaticResource Rotate270}"/>
                 <DataGridTextColumn Header="SBP" Binding="{Binding SonneBornBergerPunkte}" HeaderStyle="{StaticResource Rotate270}"/>
                 <DataGridTextColumn Header="Satzdiff." Binding="{Binding SatzDifferenz}" HeaderStyle="{StaticResource Rotate270}"/>
-                <DataGridTemplateColumn Header="Gegnerprofil">
+                <DataGridTemplateColumn Header="Gegnerprofil" Width="*" CanUserResize="False">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ItemsControl ItemsSource="{Binding Path=GegnerProfil}">
+                            <ItemsControl ItemsSource="{Binding GegnerProfil}" VerticalContentAlignment="Stretch">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <VirtualizingStackPanel Orientation="Horizontal"/>
+                                        <WrapPanel ScrollViewer.VerticalScrollBarVisibility="Disabled" />
                                     </ItemsPanelTemplate>
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>

--- a/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml
+++ b/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml
@@ -10,7 +10,7 @@
         <local:SpielKlassenkonverter x:Key="SpielKlassenkonverter"/>
         <local:GeschlechtKonverter x:Key="GeschlechtKonverter"/>
         <local:RangListeSpielerListe x:Key="Spieler"/>
-        <local:GridIndexConverter x:Key="GridIndexConverter"/>        
+        <local:GridIndexConverter x:Key="GridIndexConverter"/>
     </UserControl.Resources>
     <Grid Margin="20">
         <Grid.RowDefinitions>
@@ -18,12 +18,28 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0" Orientation="Horizontal">
-            <TextBlock x:Name="AktuellesDatum" Grid.Row="0" Text="14.12.1013" Margin="20,0,0,0"/>
+            <TextBlock x:Name="AktuellesDatum" Grid.Row="0" Text="14.12.1013"/>
+            <TextBlock Text="Rangliste" Margin="20,0,0,0" FontWeight="Bold"/>
             <TextBlock x:Name="KlassementName" Grid.Row="0" Text="Klasse D" Margin="20,0,0,0"/>
-            <TextBlock x:Name="RundenNummer" Grid.Row="0" Text="Runde Nr. 4" Margin="20,0,0,0"/>            
+            <TextBlock x:Name="RundenNummer" Grid.Row="0" Text="Runde Nr. 4" Margin="20,0,0,0"/>
         </StackPanel>
-        
-        <DataGrid Grid.Row="1" x:Name="SpielerRangListe" DataContext="{StaticResource Spieler}" d:DataContext="{d:DesignInstance Type=local:DesignSpielerListe, IsDesignTimeCreatable=True}" ItemsSource="{Binding}" AutoGenerateColumns="False" RowHeight="20" HeadersVisibility="Column" GridLinesVisibility="Horizontal" CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled">
+
+        <DataGrid Grid.Row="1" x:Name="SpielerRangListe" DataContext="{StaticResource Spieler}" d:DataContext="{d:DesignInstance Type=local:DesignSpielerListe, IsDesignTimeCreatable=True}" ItemsSource="{Binding}" RowHeight="20" HeadersVisibility="Column" GridLinesVisibility="Horizontal" CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled" AutoGenerateColumns="False" IsSynchronizedWithCurrentItem="False" Grid.RowSpan="2">
+            <DataGrid.Resources>
+                <Style x:Name="Rotate270" x:Key="Rotate270" 
+               TargetType="{x:Type DataGridColumnHeader}" >
+                    <Setter Property="LayoutTransform">
+                        <Setter.Value>
+                            <TransformGroup>
+                                <ScaleTransform/>
+                                <SkewTransform/>
+                                <RotateTransform Angle="270"/>
+                                <TranslateTransform/>
+                            </TransformGroup>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </DataGrid.Resources>
             <DataGrid.Columns>
                 <DataGridTextColumn x:Name="NummerColumn" Header="Rang">
                     <DataGridTextColumn.Binding>
@@ -32,17 +48,23 @@
                             <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type DataGrid}}" />
                         </MultiBinding>
                     </DataGridTextColumn.Binding>
-                </DataGridTextColumn>                                     
-                <DataGridTextColumn Header="Vorname" Binding="{Binding Vorname}" />
-                <DataGridTextColumn Header="Nachname" Binding="{Binding Nachname}"/>
-                <DataGridTextColumn Header="ID" Binding="{Binding StartNummer}"/>
-                <DataGridTextColumn Header="Geschl." Binding="{Binding Geschlecht, Converter={StaticResource GeschlechtKonverter}}"/>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Name">
+                    <DataGridTextColumn.Binding>
+                        <MultiBinding StringFormat="{}{0}, {1}" >
+                            <Binding Path="Nachname"/>
+                            <Binding Path="Vorname"/>
+                        </MultiBinding>
+                    </DataGridTextColumn.Binding>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="ID" Binding="{Binding StartNummer}" />
+                <DataGridTextColumn Header="Geschl." Binding="{Binding Geschlecht, Converter={StaticResource GeschlechtKonverter}}" HeaderStyle="{StaticResource Rotate270}"/>
                 <DataGridTextColumn Header="Verein" Binding="{Binding Vereinsname}"/>
-                <DataGridTextColumn Header="Tn Kl." Binding="{Binding Geburtsjahr, Converter={StaticResource SpielKlassenkonverter}}"/>
-                <DataGridTextColumn Header="Punkte" Binding="{Binding Punkte}"/>
-                <DataGridTextColumn Header="BHP" Binding="{Binding BuchholzPunkte}"/>
-                <DataGridTextColumn Header="SBP" Binding="{Binding SonneBornBergerPunkte}"/>
-                <DataGridTextColumn Header="Satzdiff" Binding="{Binding SatzDifferenz}"/>                
+                <DataGridTextColumn Header="Klasse" Binding="{Binding Geburtsjahr, Converter={StaticResource SpielKlassenkonverter}}" HeaderStyle="{StaticResource Rotate270}"/>
+                <DataGridTextColumn Header="Punkte" Binding="{Binding Punkte}" HeaderStyle="{StaticResource Rotate270}"/>
+                <DataGridTextColumn Header="BHP" Binding="{Binding BuchholzPunkte}" HeaderStyle="{StaticResource Rotate270}"/>
+                <DataGridTextColumn Header="SBP" Binding="{Binding SonneBornBergerPunkte}" HeaderStyle="{StaticResource Rotate270}"/>
+                <DataGridTextColumn Header="Satzdiff." Binding="{Binding SatzDifferenz}" HeaderStyle="{StaticResource Rotate270}"/>
                 <DataGridTemplateColumn Header="Gegnerprofil">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
@@ -57,10 +79,10 @@
                                         <TextBlock Text="{Binding}" Margin="0,0,5,0"/>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
-                            </ItemsControl>                            
+                            </ItemsControl>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>                
+                </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
     </Grid>

--- a/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml.vb
@@ -4,17 +4,16 @@ Imports PPC_Manager
 Public Class RanglisteSeite
 
     Public Sub New(altersgruppe As String,
-                   rundenNummer As Integer,
                    elemente As IEnumerable(Of Spieler),
-                   spielpartien As IEnumerable(Of SpielPartie),
+                   spielRunden As IEnumerable(Of SpielRunde),
                    spielstand As ISpielstand)
         ' This call is required by the designer.
         InitializeComponent()
         KlassementName.Text = altersgruppe
         AktuellesDatum.Text = Date.Now.ToString("dd.MM.yyyy")
-        Me.RundenNummer.Text = String.Format("Runde Nr. {0}", rundenNummer)
+        RundenNummer.Text = String.Format("Runde Nr. {0}", spielRunden.Count - 1)
 
-        Dim druckSpieler = From x In elemente Select New RangListeSpieler(x, spielpartien, spielstand)
+        Dim druckSpieler = From x In elemente Select New RangListeSpieler(x, spielRunden, spielstand)
 
         Dim res = CType(FindResource("Spieler"), RangListeSpielerListe)
         For Each s In druckSpieler
@@ -58,31 +57,33 @@ End Class
 Public Class RangListeSpieler
     Inherits Spieler
 
-    Private ReadOnly _Spielpartien As IEnumerable(Of SpielPartie)
+    Private ReadOnly _spielRunden As IEnumerable(Of SpielRunde)
     Private ReadOnly _Spielstand As ISpielstand
 
     Public Sub New(spieler As Spieler,
-                   spielPartien As IEnumerable(Of SpielPartie),
+                   spielRunden As IEnumerable(Of SpielRunde),
                    spielstand As ISpielstand)
         MyBase.New(spieler)
-        _Spielpartien = spielPartien
+        _spielRunden = spielRunden
         _Spielstand = spielstand
-
     End Sub
 
-    Public ReadOnly Property MeineSpieleDruck As IEnumerable(Of String)
+    Public ReadOnly Property GegnerProfil As IEnumerable(Of String)
         Get
             Dim l As New List(Of String)
-            Dim gespieltePartien = From x In _Spielpartien Where x.SpielerLinks = Me Or x.SpielerRechts = Me
-            For Each s In gespieltePartien
+            For Each runde In _spielRunden
+                Dim gespieltePartien = From x In runde Where x.SpielerLinks = Me Or x.SpielerRechts = Me
+                For Each partie In gespieltePartien
+                    If TypeOf partie Is FreiLosSpiel Then Continue For
 
-                Dim text = s.MeinGegner(Me).StartNummer.ToString
-                If _Spielstand.HatPartieGewonnen(s, Me) Then
-                    text &= "G"
-                Else
-                    text &= "V"
-                End If
-                l.Add(text)
+                    Dim text = partie.GegnerVon(Me).StartNummer.ToString
+                    If _Spielstand.HatPartieGewonnen(partie, Me) Then
+                        text &= "G"
+                    Else
+                        text &= "V"
+                    End If
+                    l.Add(text)
+                Next
             Next
             Return l
         End Get

--- a/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml.vb
@@ -3,12 +3,30 @@ Imports PPC_Manager
 
 Public Class RanglisteSeite
 
+    Public Function RowWidth() As Int32
+        Return 600
+    End Function
+
+    Private RangOffset As Int32
+
     Public Sub New(altersgruppe As String,
                    elemente As IEnumerable(Of Spieler),
                    spielRunden As IEnumerable(Of SpielRunde),
-                   spielstand As ISpielstand)
+                   spielstand As ISpielstand,
+                   seitenEinstellungen As SeitenEinstellung)
+
         ' This call is required by the designer.
         InitializeComponent()
+        Height = seitenEinstellungen.Höhe
+        Width = seitenEinstellungen.Breite
+        FixedPage.SetLeft(Me, seitenEinstellungen.AbstandX)
+        FixedPage.SetTop(Me, seitenEinstellungen.AbstandY)
+
+        Dim sz As New Size(seitenEinstellungen.Breite, seitenEinstellungen.Höhe)
+        Measure(sz)
+        Arrange(New Rect(New Point, sz))
+        UpdateLayout()
+
         KlassementName.Text = altersgruppe
         AktuellesDatum.Text = Date.Now.ToString("dd.MM.yyyy")
         RundenNummer.Text = String.Format("Runde Nr. {0}", spielRunden.Count - 1)

--- a/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/Output/RanglisteSeite.xaml.vb
@@ -7,16 +7,20 @@ Public Class RanglisteSeite
         Return 600
     End Function
 
-    Private RangOffset As Int32
 
     Public Sub New(altersgruppe As String,
                    elemente As IEnumerable(Of Spieler),
                    spielRunden As IEnumerable(Of SpielRunde),
                    spielstand As ISpielstand,
-                   seitenEinstellungen As SeitenEinstellung)
+                   seitenEinstellungen As SeitenEinstellung,
+                   RangOffset As Int32)
 
         ' This call is required by the designer.
         InitializeComponent()
+        Dim converter = CType(FindResource("GridIndexConverter"), GridIndexConverter)
+        converter.Offset = RangOffset
+
+
         Height = seitenEinstellungen.Höhe
         Width = seitenEinstellungen.Breite
         FixedPage.SetLeft(Me, seitenEinstellungen.AbstandX)
@@ -43,8 +47,6 @@ Public Class RanglisteSeite
     Public Sub New(seite As RanglisteSeite)
         InitializeComponent()
         Dim converter = CType(FindResource("GridIndexConverter"), GridIndexConverter)
-        Dim converterAlt = CType(seite.FindResource("GridIndexConverter"), GridIndexConverter)
-        converter.Offset = converterAlt.Offset
         KlassementName.Text = seite.KlassementName.Text
         AktuellesDatum.Text = seite.AktuellesDatum.Text
         Me.RundenNummer.Text = seite.RundenNummer.Text

--- a/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml
+++ b/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:PPC_Manager"
         mc:Ignorable="d"
-        Title="Druck Einstellungen" Height="268.747" Width="545.069" d:DataContext="{d:DesignInstance {x:Type local:DruckEinstellungen}, IsDesignTimeCreatable=True}">
+        Title="Druck Einstellungen" Height="268.747" Width="545.069" d:DataContext="{d:DesignInstance {x:Type local:DruckEinstellungen}, IsDesignTimeCreatable=True}" ResizeMode="NoResize">
     <Grid>
         <Grid.Resources>
             <local:PrintDialogZuStringConverter x:Key="PrintDialogZuStringConverter" />
@@ -53,8 +53,6 @@
                 </MultiBinding>
             </Button.IsEnabled>
         </Button>
-        <Button x:Name="Schließen" Content="Schließen" HorizontalAlignment="Left" 
-                Margin="10,0,0,6" Width="75" Grid.Row="5" Height="20" VerticalAlignment="Bottom" IsCancel="True"/>
-        
+        <Button x:Name="Schließen" Content="Schließen" HorizontalAlignment="Left" Margin="10,0,0,6" Width="75" Grid.Row="5" Height="20" VerticalAlignment="Bottom" IsCancel="True"/>
     </Grid>
 </Window>

--- a/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml
+++ b/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml
@@ -38,10 +38,10 @@
         <ToggleButton x:Name="Schiedsrichterzettel" Content="Schiedsrichterzettel" Grid.Row="2" Style="{StaticResource ToggleButtonStyle}" IsChecked="{Binding DruckeSchiedsrichterzettel}"/>
         <ToggleButton x:Name="Spielergebnisse" Content="Spielergebnisse" Grid.Row="3" Style="{StaticResource ToggleButtonStyle}" IsChecked="{Binding DruckeSpielergebnisse}"/>
         <ToggleButton x:Name="Rangliste" Content="Rangliste" Grid.Row="4" Style="{StaticResource ToggleButtonStyle}" IsChecked="{Binding DruckeRangliste}"/>
-        <Button x:Name="NeuePaarungenEinstellungen" Grid.Row="1" Grid.Column="1" Content="{Binding EinstellungenNeuePaarungen, Converter={StaticResource PrintDialogZuStringConverter}, Mode=TwoWay, NotifyOnSourceUpdated=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ButtonStyle}" Click="Button_Click" />
-        <Button x:Name="SchiedsrichterzettelEinstelllungen" Grid.Row="2" Grid.Column="1" Content="{Binding EinstellungenSchiedsrichterzettel, Converter={StaticResource PrintDialogZuStringConverter}}" Style="{StaticResource ButtonStyle}" Click="Button_Click" />
-        <Button x:Name="SpielergebnisseEinstellungen" Grid.Row="3" Grid.Column="1" Content="{Binding EinstellungenSpielergebnisse, Converter={StaticResource PrintDialogZuStringConverter}}" Style="{StaticResource ButtonStyle}" Click="Button_Click" />
-        <Button x:Name="RanglisteEinstellungen" Grid.Row="4" Grid.Column="1" Content="{Binding EinstellungenRangliste, Converter={StaticResource PrintDialogZuStringConverter}}" Style="{StaticResource ButtonStyle}" Click="Button_Click" />
+        <Button x:Name="NeuePaarungenEinstellungen" Grid.Row="1" Grid.Column="1" Content="{Binding EinstellungenNeuePaarungen, Converter={StaticResource PrintDialogZuStringConverter}, Mode=TwoWay, NotifyOnSourceUpdated=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ButtonStyle}" Click="PrintSettingsClick" />
+        <Button x:Name="SchiedsrichterzettelEinstelllungen" Grid.Row="2" Grid.Column="1" Content="{Binding EinstellungenSchiedsrichterzettel, Converter={StaticResource PrintDialogZuStringConverter}}" Style="{StaticResource ButtonStyle}" Click="PrintSettingsClick" />
+        <Button x:Name="SpielergebnisseEinstellungen" Grid.Row="3" Grid.Column="1" Content="{Binding EinstellungenSpielergebnisse, Converter={StaticResource PrintDialogZuStringConverter}}" Style="{StaticResource ButtonStyle}" Click="PrintSettingsClick" />
+        <Button x:Name="RanglisteEinstellungen" Grid.Row="4" Grid.Column="1" Content="{Binding EinstellungenRangliste, Converter={StaticResource PrintDialogZuStringConverter}}" Style="{StaticResource ButtonStyle}" Click="PrintSettingsClick" />
         <Button x:Name="Drucken" Content="Drucken" 
                 Margin="0,0,10,6" Grid.Row="5" HorizontalAlignment="Right" Width="75" Height="20" VerticalAlignment="Bottom" Grid.Column="1" IsDefault="True">
             <Button.IsEnabled>

--- a/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml.vb
@@ -38,6 +38,7 @@ Public Class DruckEinstellungenDialog
     End Sub
 
     Private Sub Drucken_Click(sender As Object, e As RoutedEventArgs) Handles Drucken.Click
+
         With Einstellungen
             If .DruckeNeuePaarungen And .EinstellungenNeuePaarungen Is Nothing _
                 Or .DruckeRangliste And .EinstellungenRangliste Is Nothing _
@@ -50,6 +51,8 @@ Public Class DruckEinstellungenDialog
                 Return
             End If
         End With
+
+        CType(FindName("Drucken"), Button).IsEnabled = False 'Verhindert doppelklicken, da das Drucken eine Sekunde oder so dauert
         PrintSelectedDocuments()
         DialogResult = True
         Close()

--- a/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml.vb
@@ -7,7 +7,7 @@
     End Property
 
 
-    Private Sub Button_Click(sender As Object, e As RoutedEventArgs)
+    Private Sub PrintSettingsClick(sender As Object, e As RoutedEventArgs)
         Dim p = New PrintDialog
         If p.ShowDialog Then
             Dim b = CType(sender, Button)
@@ -28,11 +28,11 @@
 
     Private Sub Drucken_Click(sender As Object, e As RoutedEventArgs) Handles Drucken.Click
         With Einstellungen
-            If .EinstellungenNeuePaarungen Is Nothing _
-                Or .EinstellungenRangliste Is Nothing _
-                Or .EinstellungenSchiedsrichterzettel Is Nothing _
-                Or .EinstellungenSpielergebnisse Is Nothing Then
-                MessageBox.Show("Es wurden noch nicht für alle Druckansichten Einstellungen gewählt",
+            If .DruckeNeuePaarungen And .EinstellungenNeuePaarungen Is Nothing _
+                Or .DruckeRangliste And .EinstellungenRangliste Is Nothing _
+                Or .DruckeSchiedsrichterzettel And .EinstellungenSchiedsrichterzettel Is Nothing _
+                Or .DruckeSpielergebnisse And .EinstellungenSpielergebnisse Is Nothing Then
+                MessageBox.Show("Es wurden noch nicht für alle ausgewählten Druckansichten Einstellungen gewählt",
                                 "Fehlende Einstellungen",
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Exclamation)

--- a/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/DruckEinstellungenDialog.xaml.vb
@@ -1,4 +1,15 @@
-﻿Public Class DruckEinstellungenDialog
+﻿Imports PPC_Manager
+
+Public Class DruckEinstellungenDialog
+
+    Private ReadOnly _Controller As IController
+    Private ReadOnly _DruckerFabrik As IDruckerFabrik
+
+    Public Sub New(Controller As IController, DruckerFabrik As IDruckerFabrik)
+        _Controller = Controller
+        _DruckerFabrik = DruckerFabrik
+        InitializeComponent()
+    End Sub
 
     Public ReadOnly Property Einstellungen As DruckEinstellungen
         Get
@@ -39,7 +50,58 @@
                 Return
             End If
         End With
+        PrintSelectedDocuments()
         DialogResult = True
         Close()
+    End Sub
+
+    Private Sub PrintSelectedDocuments()
+        With Einstellungen
+            If .DruckeNeuePaarungen Then
+                _Focus(NeuePaarungen)
+                Dim p = _DruckerFabrik.Neu(.EinstellungenNeuePaarungen)
+                Dim doc = _Controller.DruckeNeuePaarungen(p.LeseKonfiguration)
+                p.Drucken(doc, "Neue Begegnungen - Aushang")
+                _Blur(NeuePaarungen)
+            End If
+            If .DruckeSchiedsrichterzettel Then
+                _Focus(Schiedsrichterzettel)
+                Dim p = _DruckerFabrik.Neu(.EinstellungenSchiedsrichterzettel)
+                Dim doc = _Controller.DruckeSchiedsrichterzettel(p.LeseKonfiguration)
+                p.Drucken(doc, "Schiedsrichterzettel")
+                _Blur(Schiedsrichterzettel)
+            End If
+            If .DruckeSpielergebnisse Then
+                _Focus(Spielergebnisse)
+                Dim p = _DruckerFabrik.Neu(.EinstellungenSpielergebnisse)
+                Dim doc = _Controller.DruckeSpielergebnisse(p.LeseKonfiguration)
+                p.Drucken(doc, "Spielergebnisse")
+                _Blur(Spielergebnisse)
+            End If
+            If .DruckeRangliste Then
+                _Focus(Rangliste)
+                Dim p = _DruckerFabrik.Neu(.EinstellungenRangliste)
+                Dim doc = _Controller.DruckeRangliste(p.LeseKonfiguration)
+                p.Drucken(doc, "Rangliste")
+                _Blur(Rangliste)
+            End If
+        End With
+    End Sub
+
+    Private _OriginalContent As Object
+
+    Private Sub _Focus(Button As Primitives.ToggleButton)
+        With Button
+            _OriginalContent = .Content
+            .Content = "→ " + .Content.ToString()
+            .FontWeight = FontWeights.Bold
+        End With
+    End Sub
+
+    Private Sub _Blur(Button As Primitives.ToggleButton)
+        With Button
+            .Content = _OriginalContent
+            .FontWeight = FontWeights.Normal
+        End With
     End Sub
 End Class

--- a/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
@@ -49,6 +49,10 @@ Class MainWindow
         Begegnungen.SpielPartienListe.IstAbgeschlossen = AddressOf _Spielstand.IstAbgeschlossen
         Begegnungen.IstAbgeschlossen = AddressOf _Spielstand.IstAbgeschlossen
         Begegnungen.DetailGrid.IstAbgeschlossen = AddressOf _Spielstand.IstAbgeschlossen
+        With My.Application.Info.Version
+            versionNumber.Text = String.Format("Version: {0}.{1}", .Major, .Minor)
+            buildNumber.Text = String.Format("(Build: {0}.{1})", .Build, .Revision)
+        End With
     End Sub
 
     Private Sub MyWindow_Loaded(sender As Object, e As RoutedEventArgs) Handles MyWindow.Loaded

--- a/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
@@ -257,29 +257,6 @@ Class MainWindow
         dialog.ShowDialog()
     End Sub
 
-    Private Sub Drucken_Executed(ByVal sender As System.Object, ByVal e As System.Windows.Input.ExecutedRoutedEventArgs)
-        Dim dialog = New PrintDialog
-        If dialog.ShowDialog Then
-            Dim p = _DruckerFabrik.Neu(dialog)
-            Dim doc = _Controller.DruckeNeuePaarungen(p.LeseKonfiguration)
-            Dim doc2 = _Controller.DruckeSchiedsrichterzettel(p.LeseKonfiguration)
-            p.Drucken(doc, "Neue Begegnungen - Aushang")
-            p.Drucken(doc2, "Schiedsrichterzettel")
-        End If
-
-    End Sub
-
-    Private Sub RanglisteDrucken_Executed(sender As Object, e As ExecutedRoutedEventArgs)
-        Dim dialog = New PrintDialog
-        If dialog.ShowDialog Then
-            Dim p = _DruckerFabrik.Neu(dialog)
-            Dim doc = _Controller.DruckeRangliste(p.LeseKonfiguration)
-            Dim doc2 = _Controller.DruckeSpielergebnisse(p.LeseKonfiguration)
-            p.Drucken(doc, "Rangliste")
-            p.Drucken(doc2, "Spielergebnisse")
-        End If
-    End Sub
-
     Private Sub Exportieren_Executed(ByVal sender As Object, ByVal e As ExecutedRoutedEventArgs)
 
         With LadenNeu.SpeichernDialog

--- a/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
@@ -247,35 +247,11 @@ Class MainWindow
 
         End With
 
-        Dim dialog = New DruckEinstellungenDialog With {
+        Dim dialog = New DruckEinstellungenDialog(_Controller, _DruckerFabrik) With {
             .DataContext = _DruckEinstellungen
         }
 
-        If Not dialog.ShowDialog Then
-            Return
-        End If
-        With _DruckEinstellungen
-            If .DruckeNeuePaarungen Then
-                Dim p = _DruckerFabrik.Neu(.EinstellungenNeuePaarungen)
-                Dim doc = _Controller.DruckeNeuePaarungen(p.LeseKonfiguration)
-                p.Drucken(doc, "Neue Begegnungen - Aushang")
-            End If
-            If .DruckeRangliste Then
-                Dim p = _DruckerFabrik.Neu(.EinstellungenRangliste)
-                Dim doc = _Controller.DruckeRangliste(p.LeseKonfiguration)
-                p.Drucken(doc, "Rangliste")
-            End If
-            If .DruckeSchiedsrichterzettel Then
-                Dim p = _DruckerFabrik.Neu(.EinstellungenSchiedsrichterzettel)
-                Dim doc = _Controller.DruckeSchiedsrichterzettel(p.LeseKonfiguration)
-                p.Drucken(doc, "Schiedsrichterzettel")
-            End If
-            If .DruckeSpielergebnisse Then
-                Dim p = _DruckerFabrik.Neu(.EinstellungenSpielergebnisse)
-                Dim doc = _Controller.DruckeSpielergebnisse(p.LeseKonfiguration)
-                p.Drucken(doc, "Spielergebnisse")
-            End If
-        End With
+        dialog.ShowDialog()
     End Sub
 
     Private Sub Drucken_Executed(ByVal sender As System.Object, ByVal e As System.Windows.Input.ExecutedRoutedEventArgs)

--- a/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
@@ -222,26 +222,35 @@ Class MainWindow
 
     Private Sub AllesDrucken_Executed(ByVal sender As Object, ByVal e As ExecutedRoutedEventArgs)
 
+        Dim defaultPrintSettings = New PrintDialog
+
         Dim AktuellePartien = _Spielrunden.Peek.ToList
         Dim AlleAbgeschlossen = Aggregate x In AktuellePartien Into All(_Spielstand.IstAbgeschlossen(x))
 
-        If AlleAbgeschlossen Then
-            With _DruckEinstellungen
+        With _DruckEinstellungen
+            If AlleAbgeschlossen Then
                 .DruckeNeuePaarungen = False
                 .DruckeRangliste = True
                 .DruckeSchiedsrichterzettel = False
                 .DruckeSpielergebnisse = True
-            End With
-        Else
-            With _DruckEinstellungen
+            Else
                 .DruckeNeuePaarungen = True
                 .DruckeRangliste = False
                 .DruckeSchiedsrichterzettel = True
                 .DruckeSpielergebnisse = False
-            End With
-        End If
-        Dim dialog = New DruckEinstellungenDialog
-        dialog.DataContext = _DruckEinstellungen
+            End If
+
+            .EinstellungenNeuePaarungen = defaultPrintSettings
+            .EinstellungenRangliste = defaultPrintSettings
+            .EinstellungenSchiedsrichterzettel = defaultPrintSettings
+            .EinstellungenSpielergebnisse = defaultPrintSettings
+
+        End With
+
+        Dim dialog = New DruckEinstellungenDialog With {
+            .DataContext = _DruckEinstellungen
+        }
+
         If Not dialog.ShowDialog Then
             Return
         End If

--- a/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/View/MainWindow.xaml.vb
@@ -230,21 +230,20 @@ Class MainWindow
         With _DruckEinstellungen
             If AlleAbgeschlossen Then
                 .DruckeNeuePaarungen = False
-                .DruckeRangliste = True
                 .DruckeSchiedsrichterzettel = False
                 .DruckeSpielergebnisse = True
+                .DruckeRangliste = True
             Else
                 .DruckeNeuePaarungen = True
-                .DruckeRangliste = False
                 .DruckeSchiedsrichterzettel = True
                 .DruckeSpielergebnisse = False
+                .DruckeRangliste = False
             End If
 
             .EinstellungenNeuePaarungen = defaultPrintSettings
             .EinstellungenRangliste = defaultPrintSettings
             .EinstellungenSchiedsrichterzettel = defaultPrintSettings
             .EinstellungenSpielergebnisse = defaultPrintSettings
-
         End With
 
         Dim dialog = New DruckEinstellungenDialog(_Controller, _DruckerFabrik) With {
@@ -314,6 +313,5 @@ Class MainWindow
         Begegnungen.BegegnungenFiltern = filtern
         Begegnungen.Update()
     End Sub
-
 
 End Class

--- a/Trunk/PPC Manager/PPC Manager/View/SpielPartienListe.xaml
+++ b/Trunk/PPC Manager/PPC Manager/View/SpielPartienListe.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:PPC_Manager"
              mc:Ignorable="d"             
              d:DataContext="{d:DesignInstance local:DesignSpielPartien, IsDesignTimeCreatable=True}"
+             d:DesignWidth="793"
              >
     <UserControl.Resources>
         <local:OpacityConverter x:Key="OpacityConverter"/>
@@ -13,13 +14,14 @@
     <UserControl.CommandBindings>
         <CommandBinding Command="Delete" CanExecute="SpielPartie_Löschen_CanExecute" Executed="SpielPartie_Löschen_Executed"/>
     </UserControl.CommandBindings>
-    <ListBox  Name="SpielPartienView"  FontSize="24"                  
+    <ListBox  Name="SpielPartienView"  FontSize="24"
                  ItemsSource="{Binding Mode=OneWay}" IsSynchronizedWithCurrentItem="True"
                  VerticalContentAlignment="Center" ScrollViewer.HorizontalScrollBarVisibility="Disabled" TextBlock.FontSize="15">
         <ListBox.Resources>
             <DataTemplate DataType="{x:Type local:FreiLosSpiel}">
                 <Border BorderBrush="Black" BorderThickness="1" CornerRadius="2">
-                    <StackPanel Width="{Binding Source={x:Static Member=local:MySettings.Default}, Path=PartieBreite}">
+                    <StackPanel Width="{Binding Source={x:Static Member=local:MySettings.Default}, Path=PartieBreite}"
+                          Opacity="{Binding Path=MySelf, Converter={StaticResource OpacityConverter}}">
                         <TextBlock Text="{Binding Path=SpielerLinks.Nachname}" FontSize="18" TextBlock.TextTrimming="CharacterEllipsis" />
                         <TextBlock Text="{Binding Path=SpielerLinks.Vorname}" TextBlock.TextTrimming="CharacterEllipsis" />
                         <TextBlock Text="(Freilos)" Margin="30,0,0,0" FontStyle="Italic"/>

--- a/Trunk/PPC Manager/PPC Manager/View/mainwindow.xaml
+++ b/Trunk/PPC Manager/PPC Manager/View/mainwindow.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     Name="MyWindow" SnapsToDevicePixels="True" mc:Ignorable="d"         
-    Height="448" Width="1035" Icon="/PPC%20Manager;component/Icon.ico"
+    Height="720" Width="1280" Icon="/PPC%20Manager;component/Icon.ico"
     >
     <Window.CommandBindings>
         <CommandBinding Command="ApplicationCommands.New" CanExecute="NeuePartie_CanExecute" Executed="NeuePartie_Executed" />

--- a/Trunk/PPC Manager/PPC Manager/View/mainwindow.xaml
+++ b/Trunk/PPC Manager/PPC Manager/View/mainwindow.xaml
@@ -33,9 +33,10 @@
         </Grid.ColumnDefinitions>
         <local:Hauptmenü x:Name="Hauptmenü" Grid.Row="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="18" />
         <local:LiveListe Grid.Row="1" Grid.Column="0" x:Name="LiveListe" Margin="5,5,15,3" TextBlock.FontSize="20" />
-        <GridSplitter Grid.Row="1" Grid.Column ="0" Background="Blue" Width="5"
+        <GridSplitter Grid.Row="1" Grid.Column ="0" Background="#FFBDBDBD" Width="5"
                 HorizontalAlignment="Right" VerticalAlignment="Stretch" Margin="0,5,5,5" />
         <local:Begegnungen Grid.Row="1" Grid.Column="1"  x:Name="Begegnungen" Margin="0,28,5,3" />
-        <TextBlock x:Name="versionNumber" HorizontalAlignment="Left" Margin="5,0,5,2" Grid.Row="2" TextWrapping="Wrap" Text="Version 1.2" VerticalAlignment="Center" Opacity="0.8" Height="16"/>
+        <TextBlock x:Name="versionNumber" HorizontalAlignment="Left" Margin="5,0,5,2" Grid.Row="2" TextWrapping="Wrap" Text="Version MAJOR.MINOR" VerticalAlignment="Center" Opacity="0.8" Height="16"/>
+        <TextBlock x:Name="buildNumber" HorizontalAlignment="Right" Margin="5,0,5,2" Grid.Row="2" TextWrapping="Wrap" Text="(Build: BUILD.REVISION)" VerticalAlignment="Center" Opacity="0.8" Height="16" Foreground="#FF979797"/>
     </Grid>
 </Window>


### PR DESCRIPTION
Neue Funktionen und behobene Fehler:

## Nur ausgewählte Druckaufträge erfordern Einstellungen
Bisher war es nötig alle (vier) Ausdrucke zu konfigurieren, selbst wenn man nur
einen einzigen Drucken wollte.
Ab jetzt reicht es, die zum drucken ausgewählten Dokumente zu
konfigurieren

## Standard Druckeinstellungen
wenn man nun den druckdialog öffnet, ist der Standarddrucker für alle
Dokumente voreingestellt.
Dies sollte verhindern, dass man die Fehlermeldung über fehlende
Druckeinstellungen angezeigt bekommt.

## Aktueller Druckauftrag wird hervorgehoben
Beim PDF Export über den Druckerdialog geht nacheinander für jedes Dokument ein
Dialog zum festlegen des Dateinamens und -Speicherorts auf, ohne dass
ersichtlich wäre, welche Datei gerade gespeichert werden soll.
Leider bietet VB.Net keine Option an, den Titel des Speicherdialogs zu
ändern oder einen Dateinamen vorzuschlagen. In einem Versuch, hier doch etwas
Klarheit zu schaffen, bleibt der Druckeinstellungen Dialog nun während
des Exports geöffnet und das aktuelle Dokument wird über den jeweiligen
`→ ToggleButton` markiert.

![grafik](https://user-images.githubusercontent.com/9429273/192834261-0da4bdd8-91b7-41c8-a2e3-e87decf3219f.png)


## Korrekte Ausgabe f. "Freilos" auf Ergebnisausdruck 
![grafik](https://user-images.githubusercontent.com/9429273/192835000-483a34ba-0014-4d3e-b21d-4c48d499a868.png)


##  Rangliste überarbeitet
fixes #27 

- Namen werden jetzt in einer Spalte als Nachname, Vorname
angzeigt.
- Bei Spalten mit kurzem Inhalt ist die Überschrift um 90° gedreht
- Das Gegnerprofil zeigt nun die gesamte Historie anstatt nur des letzten
Spiels an.
- Freilosspiele werden nun nicht mehr als gewonnene Spiele im
Gegnerprofil angezeigt.
- Das Gegnerprofil auf der Rangliste nimmt nun mehrere Zeilen ein wenn
nötig. Die Höhe der einzelnen Zeilen wird ausgemessen und die einzelnen
Seiten korrekt und als Textelemente (nicht als Bild) erzeugt.
- Die Seitenränder werden nicht mehr ignoriert.

![grafik](https://user-images.githubusercontent.com/9429273/192836274-44c25d3d-c778-4ad1-9ed1-02df0fa1b28b.png)

## Fehlerbehandlung beim Drucken
Statt abzustürzen zeigt das Programm nun eine Fehlermeldung an,
dass ein Dokument nicht gespeichert werden konnte mit dem Hinweis,
dass es in einem anderen Programm geöffnet sein könnte

![grafik](https://user-images.githubusercontent.com/9429273/192837058-e6d07298-3496-46d7-b61b-3a231525bfbd.png)


## Crash beim Doppelklicken von "Drucken" behoben 

## Freilosspiel ausgegraut
Freilosspiele werden nun - wie abgeschlossene Partien - ausgegraut dargestellt, da es hier keine
Daten zu pflegen gibt.

![grafik](https://user-images.githubusercontent.com/9429273/192837513-d5f295d9-6c2b-486d-a28f-0a582326c5d3.png)


## Startgröße des Hauptfensters auf 720p festgelegt 

## Installerprobleme behoben
Die AssemblyFileVersion wurde nie gesetzt, wodurch der Installer die
.exe bei einer neuen Version nicht ausgetauscht hat.
Dies sollte auf diese Weise behoben sein