### PR TITLE
Klassement Tabs

### DIFF
--- a/Trunk/PPC Manager/PPC Manager/Application.xaml.vb
+++ b/Trunk/PPC Manager/PPC Manager/Application.xaml.vb
@@ -10,6 +10,9 @@ Class Application
         My.Settings.Save()
     End Sub
 
+    Public spielRegeln As SpielRegeln
+    Public xmlPfad As String
+
     Public Sub CrashBehandeln(sender As Object, args As UnhandledExceptionEventArgs)
         Dim nachricht = ""
         If TypeOf args.ExceptionObject Is FileNotFoundException Then
@@ -22,6 +25,93 @@ Class Application
         f.ShowDialog()
     End Sub
 
+    Public Sub LadeCompetition(sender As Object, klassement As String)
+        Dim AktiveCompetition As Competition
+        Dim spielRunden = New SpielRunden
+        Dim spielpartien = spielRunden.SelectMany(Function(m) m)
+        Dim ausgeschiedeneIds = spielRunden.SelectMany(Function(m) m.AusgeschiedeneSpielerIDs)
+        Dim spielstand = New Spielstand(SpielRegeln.Gewinnsätze)
+        Dim spielverlauf = New Spielverlauf(spielpartien, ausgeschiedeneIds, spielstand)
+        Dim AlleCompetitions As Collection(Of String)
+
+        Try
+            Dim doc = XDocument.Load(xmlPfad)
+            AlleCompetitions = New Collection(Of String)(doc.Root.<competition>.Select(Function(x) x.Attribute("age-group").Value).ToList)
+            AktiveCompetition = AusXML.CompetitionFromXML(xmlPfad, doc, klassement, spielRegeln, spielRunden)
+        Catch ex As SpielDatenUnvollständigException
+            MessageBox.Show(String.Format("Es gibt noch {0} Spieler dessen Anwesenheitsstatus unbekannt ist. Bitte korrigieren bevor das Turnier beginnt.", ex.UnvollständigCount),
+            "Spieldaten unvollständig", MessageBoxButton.OK, MessageBoxImage.Error)
+            Shutdown()
+            Return
+        End Try
+
+        Resources("KlassementName") = AktiveCompetition.Altersgruppe
+        Dim speichern = Sub() ZuXML.SaveXML(xmlPfad, SpielRegeln, klassement, AktiveCompetition.SpielRunden)
+        Dim excelVerlauf = New Spielverlauf(spielRunden.Skip(1).Reverse.SelectMany(Function(m) m),
+                                        spielRunden.Skip(1).SelectMany(Function(m) m.AusgeschiedeneSpielerIDs),
+                                        spielstand)
+        Dim excelFabrik = New ExcelFabrik(spielstand, excelVerlauf)
+        Dim vergleicher = New SpielerInfoComparer(spielverlauf, SpielRegeln.SatzDifferenz, SpielRegeln.SonneBornBerger)
+        Dim r = New ReportFactory(xmlPfad,
+                                  klassement,
+                                  AktiveCompetition.SpielerListe,
+                                  vergleicher,
+                                  AktiveCompetition.SpielRunden,
+                                  AddressOf excelFabrik.HoleDokument)
+        Dim ausgeschiedeneSpielerIds = spielRunden.SelectMany(Function(m) m.AusgeschiedeneSpielerIDs)
+
+        Dim AktiveListe = From x In AktiveCompetition.SpielerListe
+                          Where Not ausgeschiedeneSpielerIds.Contains(x.Id)
+                          Select x
+        Dim OrganisierePakete = Function()
+                                    Dim spielverlaufCache = New SpielverlaufCache(spielverlauf)
+                                    Dim comparer = New SpielerInfoComparer(spielverlaufCache, SpielRegeln.SatzDifferenz, SpielRegeln.SonneBornBerger)
+                                    Dim paarungsSuche = New PaarungsSuche(Of SpielerInfo)(AddressOf comparer.Compare, AddressOf spielverlaufCache.Habengegeneinandergespielt)
+                                    Dim begegnungen = New PaketBildung(Of SpielerInfo)(spielverlaufCache, AddressOf paarungsSuche.SuchePaarungen)
+                                    Dim l = AktiveListe.ToList()
+                                    l.Sort(comparer)
+                                    l.Reverse()
+                                    Return begegnungen.organisierePakete(l, spielRunden.Count - 1)
+                                End Function
+
+        Dim spielerWrapped = From x In AktiveCompetition.SpielerListe
+                             Select New Spieler(x, spielverlauf, vergleicher)
+        Dim druckFabrik = New FixedPageFabrik(
+            spielerWrapped,
+            spielRunden,
+            klassement,
+            spielstand)
+        Dim controller = New MainWindowController(speichern,
+                                                  r,
+                                                  OrganisierePakete,
+                                                  druckFabrik)
+        Dim oldWindow = MainWindow
+
+        Dim window = New MainWindow(controller,
+                                    spielerWrapped,
+                                    spielRunden,
+                                    klassement,
+                                    spielstand,
+                                    vergleicher,
+                                    New DruckerFabrik,
+                                    AlleCompetitions)
+
+        MainWindow = window
+
+        'copy position and size from old window to new window
+        If oldWindow IsNot Nothing Then
+            window.Left = oldWindow.Left
+            window.Top = oldWindow.Top
+            window.Width = oldWindow.Width
+            window.Height = oldWindow.Height
+        End If
+
+        window.Show()
+        If oldWindow IsNot Nothing Then
+            oldWindow.Close()
+        End If
+    End Sub
+
     Private Sub Application_Startup(sender As Object, e As StartupEventArgs) Handles Me.Startup
         AddHandler AppDomain.CurrentDomain.UnhandledException, AddressOf CrashBehandeln
         Me.ShutdownMode = ShutdownMode.OnExplicitShutdown
@@ -32,73 +122,11 @@ Class Application
                 Return
             End If
 
-            Dim spielRegeln = New SpielRegeln(.GewinnsätzeAnzahl.Value, .SatzDiffCheck.IsChecked, .SonneBorn.IsChecked)
-            Dim xmlPfad = .XMLPathText.Text
-            Dim klassement = .CompetitionCombo.SelectedItem.ToString
-            Dim AktiveCompetition As Competition
-            Dim spielRunden = New SpielRunden
-            Dim spielpartien = spielRunden.SelectMany(Function(m) m)
-            Dim ausgeschiedeneIds = spielRunden.SelectMany(Function(m) m.AusgeschiedeneSpielerIDs)
-            Dim spielstand = New Spielstand(spielRegeln.Gewinnsätze)
-            Dim spielverlauf = New Spielverlauf(spielpartien, ausgeschiedeneIds, spielstand)
-            Try
-                Dim doc = XDocument.Load(.XMLPathText.Text)
-                AktiveCompetition = AusXML.CompetitionFromXML(xmlPfad, doc, klassement, spielRegeln, spielRunden)
-            Catch ex As SpielDatenUnvollständigException
-                MessageBox.Show(String.Format("Es gibt noch {0} Spieler dessen Anwesenheitsstatus unbekannt ist. Bitte korrigieren bevor das Turnier beginnt.", ex.UnvollständigCount),
-                "Spieldaten unvollständig", MessageBoxButton.OK, MessageBoxImage.Error)
-                Shutdown()
-                Return
-            End Try
+            spielRegeln = New SpielRegeln(.GewinnsätzeAnzahl.Value, .SatzDiffCheck.IsChecked, .SonneBorn.IsChecked)
+            xmlPfad = .XMLPathText.Text
 
-            Resources("KlassementName") = AktiveCompetition.Altersgruppe
-            Dim speichern = Sub() ZuXML.SaveXML(xmlPfad, spielRegeln, klassement, AktiveCompetition.SpielRunden)
-            Dim excelVerlauf = New Spielverlauf(spielRunden.Skip(1).Reverse.SelectMany(Function(m) m),
-                                            spielRunden.Skip(1).SelectMany(Function(m) m.AusgeschiedeneSpielerIDs),
-                                            spielstand)
-            Dim excelFabrik = New ExcelFabrik(spielstand, excelVerlauf)
-            Dim vergleicher = New SpielerInfoComparer(spielverlauf, spielRegeln.SatzDifferenz, spielRegeln.SonneBornBerger)
-            Dim r = New ReportFactory(xmlPfad,
-                                      klassement,
-                                      AktiveCompetition.SpielerListe,
-                                      vergleicher,
-                                      AktiveCompetition.SpielRunden,
-                                      AddressOf excelFabrik.HoleDokument)
-            Dim ausgeschiedeneSpielerIds = spielRunden.SelectMany(Function(m) m.AusgeschiedeneSpielerIDs)
+            LadeCompetition(sender, .CompetitionCombo.SelectedItem.ToString)
 
-            Dim AktiveListe = From x In AktiveCompetition.SpielerListe
-                              Where Not ausgeschiedeneSpielerIds.Contains(x.Id)
-                              Select x
-            Dim OrganisierePakete = Function()
-                                        Dim spielverlaufCache = New SpielverlaufCache(spielverlauf)
-                                        Dim comparer = New SpielerInfoComparer(spielverlaufCache, spielRegeln.SatzDifferenz, spielRegeln.SonneBornBerger)
-                                        Dim paarungsSuche = New PaarungsSuche(Of SpielerInfo)(AddressOf comparer.Compare, AddressOf spielverlaufCache.Habengegeneinandergespielt)
-                                        Dim begegnungen = New PaketBildung(Of SpielerInfo)(spielverlaufCache, AddressOf paarungsSuche.SuchePaarungen)
-                                        Dim l = AktiveListe.ToList()
-                                        l.Sort(comparer)
-                                        l.Reverse()
-                                        Return begegnungen.organisierePakete(l, spielRunden.Count - 1)
-                                    End Function
-
-            Dim spielerWrapped = From x In AktiveCompetition.SpielerListe
-                                 Select New Spieler(x, spielverlauf, vergleicher)
-            Dim druckFabrik = New FixedPageFabrik(
-                spielerWrapped,
-                spielRunden,
-                klassement,
-                spielstand)
-            Dim controller = New MainWindowController(speichern,
-                                                      r,
-                                                      OrganisierePakete,
-                                                      druckFabrik)
-            Dim window = New MainWindow(controller,
-                                        spielerWrapped,
-                                        spielRunden,
-                                        klassement,
-                                        spielstand,
-                                        vergleicher, New DruckerFabrik)
-            MainWindow = window
-            window.Show()
             ShutdownMode = ShutdownMode.OnMainWindowClose
         End With
     End Sub

--- a/Trunk/PPC Manager/PPC Manager/LadenNeu.xaml
+++ b/Trunk/PPC Manager/PPC Manager/LadenNeu.xaml
@@ -22,7 +22,7 @@
                           Name="SatzDiffCheck" VerticalAlignment="Top" Width="162" 
                           IsChecked="{Binding Source={x:Static Member=local:MySettings.Default}, Path=SatzDifferenz}" />
                 <Slider Height="28" HorizontalAlignment="Left" Margin="25,59,0,0" x:Name="GewinnsätzeAnzahl" VerticalAlignment="Top" Width="162" Minimum="1" Maximum="5" 
-                        TickPlacement="BottomRight" IsSnapToTickEnabled="True" Value="{Binding Source={x:Static Member=local:MySettings.Default}, Path=GewinnSätze}" />
+                        TickPlacement="BottomRight" IsSnapToTickEnabled="True" Value="{Binding Source={x:Static Member=local:MySettings.Default}, Path=GewinnSätze}" ValueChanged="GewinnsätzeAnzahl_ValueChanged" />
 
                 <Label Height="28" HorizontalAlignment="Left" Margin="30,75,0,0" Name="Label2" VerticalAlignment="Top" Width="162" Content="{Binding Value, Converter={StaticResource Converter}, ElementName=GewinnsätzeAnzahl}" />
                 <CheckBox Content="Sonneborn-Berger" Height="26" HorizontalAlignment="Left" Margin="10,10,0,0" 

--- a/Trunk/PPC Manager/PPC Manager/View/mainwindow.xaml
+++ b/Trunk/PPC Manager/PPC Manager/View/mainwindow.xaml
@@ -24,6 +24,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="18" />
+            <RowDefinition Height="28" />
             <RowDefinition />
             <RowDefinition Height="18" />
         </Grid.RowDefinitions>
@@ -32,11 +33,21 @@
             <ColumnDefinition Width="858*" />
         </Grid.ColumnDefinitions>
         <local:Hauptmenü x:Name="Hauptmenü" Grid.Row="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="18" />
-        <local:LiveListe Grid.Row="1" Grid.Column="0" x:Name="LiveListe" Margin="5,5,15,3" TextBlock.FontSize="20" />
-        <GridSplitter Grid.Row="1" Grid.Column ="0" Background="#FFBDBDBD" Width="5"
+
+        <TabControl SelectionChanged="tabControl_SelectionChanged" x:Name="tabControl" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,5,10,0" HorizontalAlignment="Left" Width="Auto" Height="30"  >
+            <TabControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}" />
+                </DataTemplate>
+            </TabControl.ItemTemplate>
+        </TabControl>
+        
+        <local:LiveListe Grid.Row="2" Grid.Column="0" x:Name="LiveListe" Margin="5,5,15,3" TextBlock.FontSize="20" />
+        <GridSplitter Grid.Row="2" Grid.Column ="0" Background="#FFBDBDBD" Width="5"
                 HorizontalAlignment="Right" VerticalAlignment="Stretch" Margin="0,5,5,5" />
-        <local:Begegnungen Grid.Row="1" Grid.Column="1"  x:Name="Begegnungen" Margin="0,28,5,3" />
-        <TextBlock x:Name="versionNumber" HorizontalAlignment="Left" Margin="5,0,5,2" Grid.Row="2" TextWrapping="Wrap" Text="Version MAJOR.MINOR.PATCH" VerticalAlignment="Center" Opacity="0.8" Height="16"/>
-        <TextBlock x:Name="buildNumber" HorizontalAlignment="Right" Margin="5,0,5,2" Grid.Row="2" TextWrapping="Wrap" Text="(Build: REVISION)" VerticalAlignment="Center" Opacity="0.8" Height="16" Foreground="#FF979797"/>
+        <local:Begegnungen Grid.Row="2" Grid.Column="1"  x:Name="Begegnungen" Margin="0,28,5,3" />
+        
+        <TextBlock x:Name="versionNumber" HorizontalAlignment="Left" Margin="5,0,5,2" Grid.Row="3" TextWrapping="Wrap" Text="Version MAJOR.MINOR.PATCH" VerticalAlignment="Center" Opacity="0.8" Height="16"/>
+        <TextBlock x:Name="buildNumber" HorizontalAlignment="Right" Margin="5,0,5,2" Grid.Row="3" TextWrapping="Wrap" Text="(Build: REVISION)" VerticalAlignment="Center" Opacity="0.8" Height="16" Foreground="#FF979797"/>
     </Grid>
 </Window>


### PR DESCRIPTION
![grafik](https://github.com/GoppeltM/PPC-Manager/assets/9429273/c63deb61-39c6-4a63-b3b9-692ff633a24a)

Tabs hinzugefügt, mit denen man schnell zwischen verschiedenen Klassements wechseln kann.
Beim wechseln zwischen Tabs wird der aktuelle Zustand des vorherigen Klassements im XML gespeichert, auch bei unvollständig erfassten Runden. Das Wechseln ist also jederzeit problemlos möglich.

Dadurch sollte das parallele Öffnen mehrerer Instanzen unnötig sein, was das Risiko von Dateninkonsistenzen verringert.

Die Spieleinstellungen können aktuell nur im Ladebildschirm angepasst werden, hier kann man also noch optimieren.
Wenn keine Spieleinstellungen gepflegt wurden, wird Sonneborn=JA, Satzdifferenz=JA und Sätze=3 als Standard verwendet.